### PR TITLE
changed logic for retrieving mounts

### DIFF
--- a/tests/5_container_runtime.sh
+++ b/tests/5_container_runtime.sh
@@ -203,10 +203,8 @@ check_5_5() {
   fail=0
   sensitive_mount_containers=""
   for c in $containers; do
-    volumes=$(podman inspect --format '{{ .Mounts }}' "$c")
-    if podman inspect --format '{{ .VolumesRW }}' "$c" 2>/dev/null 1>&2; then
-      volumes=$(podman inspect --format '{{ .VolumesRW }}' "$c")
-    fi
+    volumes=$(podman inspect --format '{{ .VolumesRW }}' "$c")
+    [ -z "$volumes" ] && volumes=$(podman inspect --format '{{ .Mounts }}' "$c")
     # Go over each directory in sensitive dir and see if they exist in the volumes
     for v in $sensitive_dirs; do
       sensitive=0


### PR DESCRIPTION
Seems _podman inspect_ returns with an exit code of 0 even if it fails. That's why
```bash
if podman inspect --format '{{ .VolumesRW }}' "$c" 2>/dev/null 1>&2; then
```
succeeds, even if there is no _VolumesRW_ field set. This in turn will execute
```bash
volumes=$(podman inspect --format '{{ .VolumesRW }}' "$c")
```
which overrides the previously populated variable _$volumes_ which then may lead to a false positive result.

Couldn't find any good information about podman's exit codes which maybe would have led to another solution, so I'd like to propose this one.

All cases tested with podman version 3.4.2.

Cheers
Bernd

Signed-off-by: Adamowicz, Bernd <info@bernd-adamowicz.de>