### PR TITLE
Implemented check 5.27

### DIFF
--- a/podman-security-bench.sh
+++ b/podman-security-bench.sh
@@ -28,7 +28,7 @@ readonly myname
 export PATH="$PATH:/bin:/sbin:/usr/bin:/usr/local/bin:/usr/sbin/"
 
 # Check for required program(s)
-req_programs 'awk podman grep stat tee tail wc xargs truncate sed'
+req_programs 'awk podman grep stat tee tail wc xargs truncate sed skopeo jq'
 
 # Ensure podman works
 if ! podman ps -q >/dev/null 2>&1; then

--- a/tests/5_container_runtime.sh
+++ b/tests/5_container_runtime.sh
@@ -1032,18 +1032,47 @@ check_5_26() {
 }
 
 check_5_27() {
-  if [ -z "$containers" ]; then
-    return
-  fi
-
   local id="5.27"
-  local desc="Ensure that Podman commands always make use of the latest version of their image (Manual)"
+  local desc="Ensure that Podman commands always make use of the latest version of their image (Automatic)"
   local remediation="You should use proper version pinning mechanisms (the <latest> tag which is assigned by default is still vulnerable to caching attacks) to avoid extracting cached older versions. Version pinning mechanisms should be used for base images, packages, and entire images. You can customize version pinning rules according to your requirements."
   local remediationImpact="None."
   local check="$id - $desc"
   starttestjson "$id" "$desc"
 
-  info -c "$check"
+  fail=0
+  newer_images=""
+  for img in $images; do
+    imgTag=$(podman inspect "$img" --format '{{ index .RepoTags 0 }}' | tr -d '[]' | cut -f 2 -d ':')
+
+    # Bad:
+    # * hard coded command
+    # * How to reliably retrieve the repository's name?
+    # * How to configure region?
+    latestTag=$(
+      aws ecr describe-images --repository-name "mycompany/openjdk11-base" --filter tagStatus=TAGGED \
+        --region eu-central-1 --query 'sort_by(imageDetails, &imagePushedAt)[-1].imageTags[]' \
+        | jq '.[] | select(. != "latest")'
+      )
+
+    if [ "$imgTag" != "latest" ] && [ "$imgTag" != "$latestTag" ]; then
+      if [ $fail -eq 0 ]; then
+        fail=1
+        warn -s "$check"
+        warn "     * Newer image found: $img"
+        newer_images="$newer_images $img"
+        continue
+      fi
+
+      warn "     * Newer image found: $img"
+      newer_images="$newer_images $img"
+    fi
+  done
+  if [ $fail -eq 0 ]; then
+    pass -s "$check"
+    logcheckresult "PASS"
+    return
+  fi
+
   logcheckresult "INFO"
 }
 


### PR DESCRIPTION
Hi all!
This PR is just a proposal serving as a basis for some discussions. It's not a ready-to-merge PR at
all!

Basic idea of implementing check 5.27 was to retrieve the latest version tag from the registry and
compare it with the image tag under test. In my proposal this is basically implemented using AWS
ECR.

Of course it is not acceptable to have some hard coded commands serving only AWS. We need a generic
solution for this. Some ideas to address this might be:

* Provide a list of commands to be filled with arguments at runtime for other registries.
* Additionally provide a command line switch like `-r <registry-type>` to specify which command to
  use.

Or:
* Make the user provide his own command on command line or via environment variable.

Other things to consider are:

```bash
    # Bad:
    # * hard coded command
    # * How to reliably retrieve the repository's name?
    # * How to configure region?
    latestTag=$(
      aws ecr describe-images --repository-name "mycompany/openjdk11-base" --filter tagStatus=TAGGED \
        --region eu-central-1 --query 'sort_by(imageDetails, &imagePushedAt)[-1].imageTags[]' \
        | jq '.[] | select(. != "latest")'
      )
```

Maybe this proposal is too complicated to be implemented at all. However, I'd like to hear your
opinions.

Looking forward to your ideas/suggestions.