### PR TITLE
Use bash over sh

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ Or you can simply run the shell script locally:
 ```sh
 git clone git@github.com:containers/podman-security.git
 cd podman-security
-sudo sh podman-security.sh
+sudo bash podman-security.sh
 ```
 
 The Podman Security Bench has the main script called `podman-security.sh`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ You can simply run this script from your base host by running:
 ```sh
 git clone https://github.com/containers/podman-security-bench.git
 cd podman-security-bench
-sudo sh podman-security-bench.sh
+sudo bash podman-security-bench.sh
 ```
 
 ### Note

--- a/podman-security-bench.sh
+++ b/podman-security-bench.sh
@@ -46,11 +46,11 @@ Usage: ${myname}.sh [OPTIONS]
 
 Example:
   - Only run check "2.2 - Ensure the logging level is set to 'info'":
-      sh podman-bench-security.sh -c check_2_2
+      bash podman-bench-security.sh -c check_2_2
   - Run all available checks except the host_configuration group and "2.8 - Enable user namespace support":
-      sh podman-bench-security.sh -e host_configuration,check_2_8
+      bash podman-bench-security.sh -e host_configuration,check_2_8
   - Run just the container_images checks except "4.5 - Ensure Content trust for Podman is Enabled":
-      sh podman-bench-security.sh -c container_images -e check_4_5
+      bash podman-bench-security.sh -c container_images -e check_4_5
 
 Options:
   -b           optional  Do not print colors


### PR DESCRIPTION
It already uses bashisms so why not spell it out?

This fixes issues #13, #14 and #16.

An alternative would be to not use `bash` for anything.