### PR TITLE
Make volume check save in case no volumes are defined in the container

### DIFF
--- a/tests/5_container_runtime.sh
+++ b/tests/5_container_runtime.sh
@@ -203,7 +203,7 @@ check_5_5() {
   fail=0
   sensitive_mount_containers=""
   for c in $containers; do
-    volumes=$(podman inspect --format '{{ .VolumesRW }}' "$c")
+    volumes=$(podman inspect --format '{{ .VolumesRW }}' "$c" 2>/dev/null 1>&2 || true)
     [ -z "$volumes" ] && volumes=$(podman inspect --format '{{ .Mounts }}' "$c")
     # Go over each directory in sensitive dir and see if they exist in the volumes
     for v in $sensitive_dirs; do


### PR DESCRIPTION
This patch fixes an error in check 5.5 which occured, when no volumes are defined within a container.
The former error message was:

`Error: inspecting object: printing inspect output: template: inspect:1:14: executing "inspect" at <.VolumesRW>: can't evaluate field VolumesRW in type interface {}`

